### PR TITLE
Fix no-member issue on PySide2.QtCore.Signal

### DIFF
--- a/astroid/brain/brain_qt.py
+++ b/astroid/brain/brain_qt.py
@@ -78,5 +78,5 @@ MANAGER.register_transform(nodes.FunctionDef, transform_pyqt_signal, _looks_like
 MANAGER.register_transform(
     nodes.ClassDef,
     transform_pyside_signal,
-    lambda node: node.qname() == "PySide.QtCore.Signal",
+    lambda node: node.qname() in ("PySide.QtCore.Signal", "PySide2.QtCore.Signal"),
 )


### PR DESCRIPTION

<!--

Thank you for submitting a PR to astroid!

To ease our work reviewing your PR, do make sure to mark the complete the following boxes.

-->

## Steps

- [x] Fix PyCQA/pylint#2585, by adding hooks on `PySide2.QtCore.Signal` class. 

## Description

Add support for _PySide2_ in the astroid PyQt hooks, fixing the _no-members_ bug (PyCQA/pylint#2585) on the `PySide2.QtCore.Signal` class. Solution based on the patch proposed by @akai10tsuki

## Type of Changes
<!-- Leave the corresponding lines for the applicable type of change: -->
|   | Type |
| ------------- | ------------- |
| ✓  | :bug: Bug fix  |

## Related Issue

Closes PyCQA/pylint#2585

